### PR TITLE
Refocus config on Python/Jupyter, remove Java, add which-key + docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md
+
+Project guide for AI agents (Claude Code, Copilot, etc.) working on this repo.
+
+## What this is
+
+A personal Neovim configuration managed with [lazy.nvim](https://github.com/folke/lazy.nvim) and [mason.nvim](https://github.com/williamboman/mason.nvim). Primary use case: editing Python and Jupyter notebooks. Secondary: TypeScript/Angular, Lua, Rust.
+
+## Layout
+
+```
+init.lua                     # bootstraps lazy.nvim, loads remap, requires all plugins
+lua/remap.lua                # global options + non-plugin keymaps
+lua/plugins/<name>.lua       # one plugin per file; each returns a lazy.nvim spec table
+docs/KEYMAPS.md              # full keybinding reference (keep in sync with config)
+docs/SETUP.md                # macOS + Arch Linux install steps (keep in sync with system deps)
+docs/JUPYTER.md              # notebook workflow guide (keep in sync with molten/jupytext config)
+lazy-lock.json               # plugin commit lockfile, managed by :Lazy sync
+```
+
+`init.lua` walks `lua/plugins/` and loads every file — adding a new plugin just means dropping a new file in that directory.
+
+## Conventions
+
+- **Every keymap gets a `desc` field.** which-key auto-picks them up; without `desc` the popup just shows the raw `lhs`.
+- **New `<leader>` prefix? Register a group** in [`lua/plugins/which-key.lua`](lua/plugins/which-key.lua) so the popup labels it.
+- **One plugin per file** under `lua/plugins/`. Don't bundle unrelated plugins together.
+- **LSP servers go in [`lua/plugins/nvim-cmp.lua`](lua/plugins/nvim-cmp.lua)**: add to `ensure_installed` and (if non-default config is needed) add a handler under `handlers = { ... }`.
+- **Formatters go in [`lua/plugins/conform.lua`](lua/plugins/conform.lua)**: add to `formatters_by_ft`. Mason will *not* install these automatically — install via system package manager or `mason-tool-installer` if added.
+- **Treesitter parsers go in [`lua/plugins/treesitter.lua`](lua/plugins/treesitter.lua)** (`ensure_installed`).
+- **When you add or change a binding, update [`docs/KEYMAPS.md`](docs/KEYMAPS.md)** in the same change.
+- **When you change the Jupyter/notebook stack** (molten config, jupytext options, new kernel workflow), update [`docs/JUPYTER.md`](docs/JUPYTER.md).
+- **When you add or change a system-level dependency, update [`docs/SETUP.md`](docs/SETUP.md)** for *both* the macOS (Homebrew) and Arch Linux (pacman / pip) sections. Examples that require an update: a new LSP whose binary isn't installed by Mason, a new formatter, a new image backend, a different Python package, a new terminal requirement. If a change only affects pure Lua plugins managed by lazy.nvim, no update needed.
+
+## Python / Jupyter setup
+
+The Jupyter stack is **molten-nvim + jupytext.nvim + quarto-nvim + image.nvim**. `.ipynb` files are converted to markdown on read by jupytext; molten executes cells against a Jupyter kernel; image.nvim renders matplotlib output inline (Kitty terminal required).
+
+### One-time install (after `git pull` of this config)
+
+```bash
+# system
+brew install imagemagick
+
+# Python — install into the env you'll use for notebooks (or your nvim-host env)
+pip install pynvim jupyter_client cairosvg pnglatex pillow ipykernel
+```
+
+Then in Neovim:
+
+```vim
+:Lazy sync
+:UpdateRemotePlugins
+```
+
+Restart Neovim.
+
+### Smoke test
+
+1. Open `scratch.py`, add `# %%` cell markers and `print("hi")`.
+2. `:MoltenInit python3` — picks the kernel.
+3. `<leader>ml` on a line — output appears as virtual text.
+4. `import matplotlib.pyplot as plt; plt.plot([1,2,3]); plt.show()` — image renders inline (Kitty).
+
+## Language servers
+
+| Filetype | LSP(s) | Where |
+|---|---|---|
+| Python | `pyright` (types/hover) + `ruff` (lint) | nvim-cmp.lua handlers |
+| Lua | `lua_ls` | nvim-cmp.lua handlers |
+| TypeScript / JS | `ts_ls`, `eslint` | nvim-cmp.lua handlers |
+| Rust | `rust_analyzer` | default handler |
+| CSS / SCSS | `cssls` | nvim-cmp.lua handlers |
+| HTML / Tailwind / Angular / Astro | `tailwindcss`, `angularls`, `astro` | nvim-cmp.lua handlers |
+| JSON | `jsonls` | default handler |
+
+`ruff`'s `hoverProvider` is intentionally disabled so `pyright` owns hovers (avoids dual hover popups).
+
+## Formatters (conform.nvim)
+
+| Filetype | Chain |
+|---|---|
+| Python | `ruff_organize_imports` → `ruff_format` |
+| Lua | `stylua` |
+| JS/TS/JSON/CSS/HTML/Markdown | `prettierd` then `prettier` (first available) |
+
+`<leader>F` triggers a format. Formatters must be installed externally (e.g. `pip install ruff`, `brew install stylua prettierd`).
+
+## Keybinding reference
+
+See [`docs/KEYMAPS.md`](docs/KEYMAPS.md). Anything not in that file is either a default Neovim keymap or hasn't been documented yet — fix the latter.
+
+## Don't
+
+- Don't manually edit `lazy-lock.json` — let `:Lazy sync` rewrite it.
+- Don't add Java tooling. It was removed deliberately. The user doesn't write Java.
+- Don't replace `pyright` with `basedpyright` or `pylsp` without checking with the user — pyright is the chosen default.
+- Don't add `<leader>t` as a non-prefix mapping; that key is the tabby tab group.
+
+## Adding a new plugin: checklist
+
+1. Create `lua/plugins/<name>.lua` returning a lazy.nvim spec.
+2. If it adds an LSP, formatter, or treesitter parser, also update the relevant central file (see Conventions).
+3. If it introduces a new `<leader>` prefix, register the group in `which-key.lua`.
+4. Add every new keymap to `docs/KEYMAPS.md` with a `desc` field on the mapping itself.
+5. Run `:Lazy sync` and check `:checkhealth` for the plugin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # nvim
 
-This neovim config is created for my needs. It is always a work in progress as I understand neovim more.
-The plugin manager being used is lazy.nvim, and I'm using mason.nvim to manage LSP servers. Which has made it
-so much easier to manage LSP servers.
+A personal Neovim config managed with [lazy.nvim](https://github.com/folke/lazy.nvim). Primarily for editing Python and Jupyter notebooks; also handles TypeScript/Angular, Lua, and Rust.
 
+- **[`docs/SETUP.md`](docs/SETUP.md)** — install steps for macOS and Arch Linux
+- **[`docs/JUPYTER.md`](docs/JUPYTER.md)** — how to open and run Jupyter notebooks
+- **[`docs/KEYMAPS.md`](docs/KEYMAPS.md)** — full keybinding reference (or press `<space>` and wait for which-key)
+- **[`AGENTS.md`](AGENTS.md)** — project conventions for AI agents
 
-## Good Documentation for the different plugins
+## Good documentation for the different plugins
 
-- [Telescope](https://github.com/nvim-telescope/telescope.nvim)
-- [Fugitive](https://github.com/tpope/vim-fugitive)
-- [LSP Configs](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md)
+- [lazy.nvim](https://github.com/folke/lazy.nvim) · [mason.nvim](https://github.com/williamboman/mason.nvim)
+- [Telescope](https://github.com/nvim-telescope/telescope.nvim) · [Fugitive](https://github.com/tpope/vim-fugitive) · [LSP Configs](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md)
+- [molten-nvim](https://github.com/benlubas/molten-nvim) · [quarto-nvim](https://github.com/quarto-dev/quarto-nvim) · [jupytext.nvim](https://github.com/GCBallesteros/jupytext.nvim) · [image.nvim](https://github.com/3rd/image.nvim)
+- [conform.nvim](https://github.com/stevearc/conform.nvim) · [which-key.nvim](https://github.com/folke/which-key.nvim)

--- a/docs/JUPYTER.md
+++ b/docs/JUPYTER.md
@@ -1,0 +1,167 @@
+# Jupyter Notebooks in Neovim
+
+This config supports `.ipynb` files via **molten-nvim** (cell execution) + **jupytext.nvim** (notebook ↔ markdown conversion) + **quarto-nvim** (LSP inside cells) + **image.nvim** (inline plot rendering in Kitty).
+
+---
+
+## Prerequisites
+
+### 1. Install Python dependencies
+
+```bash
+pip install pynvim jupyter_client cairosvg pnglatex pillow ipykernel ruff jupytext
+```
+
+`jupytext` converts `.ipynb` ↔ markdown. `pynvim` is required for molten-nvim to talk to Neovim. All others are Jupyter runtime deps.
+
+### 2. Install plugins and register the remote plugin
+
+molten-nvim is a Python remote plugin — it needs an extra registration step that is separate from `:Lazy sync`:
+
+```vim
+:Lazy sync
+```
+
+Wait for it to finish, then:
+
+```vim
+:UpdateRemotePlugins
+```
+
+**Restart Neovim.** This step is mandatory — molten's commands (`:MoltenInit`, etc.) are only available after a restart following `:UpdateRemotePlugins`. If you see `Not an editor command: MoltenInit`, this step was skipped or Neovim wasn't restarted.
+
+### 3. Verify
+
+```vim
+:checkhealth molten
+```
+
+Should show no errors. If it reports a missing Python provider, see the troubleshooting section below.
+
+---
+
+## How it works
+
+When you open a `.ipynb` file, **jupytext.nvim** transparently converts it to a markdown representation in memory. Each cell becomes a fenced code block:
+
+````markdown
+# %% [markdown]
+This is a markdown cell.
+
+```python
+# %% a code cell title
+import pandas as pd
+df = pd.read_csv("data.csv")
+df.head()
+```
+````
+
+You edit this markdown. When you save (`:w`), jupytext converts it back to `.ipynb` on disk — the original file format is preserved and Jupyter can still open it normally.
+
+---
+
+## Opening a notebook
+
+```bash
+nvim my_notebook.ipynb
+```
+
+The file will open looking like markdown, not JSON. That's correct.
+
+---
+
+## Running cells
+
+First, start a kernel (do this once per Neovim session):
+
+```vim
+:MoltenInit python3
+```
+
+You can also specify a kernel by name if you have project-specific kernels:
+
+```vim
+:MoltenInit myproject
+```
+
+Then use these keymaps (leader = `<space>`):
+
+| Keys | Mode | Action |
+|---|---|---|
+| `<leader>mi` | n | Init kernel |
+| `<leader>ml` | n | Run current line as a cell |
+| `<leader>me` | n | Run with operator (e.g. `<leader>meip` = run paragraph) |
+| `<leader>mc` | n | Re-run current cell |
+| `<leader>mv` | v | Run visual selection |
+| `<leader>mo` | n | Enter the output window (scroll long output) |
+| `<leader>mh` | n | Hide output |
+| `<leader>mq` | n | Delete cell output |
+
+Output appears as virtual text below the cell. For plots, the image renders inline (requires Kitty terminal — see below).
+
+---
+
+## Inline plots (Kitty)
+
+If you're using Kitty (or another terminal that speaks the Kitty graphics protocol — Ghostty, WezTerm), `matplotlib` plots render inline automatically:
+
+```python
+import matplotlib.pyplot as plt
+plt.plot([1, 2, 3, 4])
+plt.title("hello")
+plt.show()
+```
+
+Run the cell with `<leader>ml` — a plot appears below the line.
+
+If you're on a non-Kitty terminal, the plot won't render inline. You can still display it externally by not calling `plt.show()` and instead saving to a file, or by switching to a different backend.
+
+---
+
+## Project-specific kernels
+
+To use a virtualenv or conda env as your kernel:
+
+```bash
+# activate your env first
+source .venv/bin/activate
+
+# register it as a Jupyter kernel
+python -m ipykernel install --user --name myproject --display-name "My Project"
+```
+
+Then in Neovim:
+
+```vim
+:MoltenInit myproject
+```
+
+---
+
+## Saving and round-tripping
+
+- `:w` writes the markdown back to `.ipynb` — safe to open in Jupyter afterwards.
+- Cell outputs are **not** stored in the markdown view. Run `:MoltenInit` + your cells to regenerate them in Neovim. The `.ipynb` file on disk retains outputs from any previous Jupyter session.
+- If you want to strip outputs from the `.ipynb` (e.g. before committing), run `jupyter nbconvert --clear-output my_notebook.ipynb`.
+
+---
+
+## Troubleshooting
+
+**File opens as raw JSON**
+: `jupytext` CLI is not installed. Run `pip install jupytext` in the Python env Neovim uses, then reopen the file.
+
+**`:MoltenInit` fails with "no Python provider"**
+: `pynvim` is not installed in the Python Neovim is using. Check `:checkhealth provider.python`, fix `vim.g.python3_host_prog` if needed, then `pip install pynvim` into that env.
+
+**`Not an editor command: MoltenInit`**
+: `:UpdateRemotePlugins` was never run, or Neovim wasn't restarted after it ran. Fix: `:Lazy sync` → `:UpdateRemotePlugins` → quit and reopen Neovim.
+
+**`:MoltenInit` fails with "remote plugin not registered"**
+: Same cause as above — run `:UpdateRemotePlugins` and restart Neovim.
+
+**No inline images**
+: Your terminal doesn't support the Kitty graphics protocol. Works: Kitty, Ghostty, WezTerm. Doesn't work: Terminal.app, iTerm2, Alacritty. Cell output still appears as text.
+
+**Output window is huge**
+: `vim.g.molten_output_win_max_height` in [`lua/plugins/molten.lua`](../lua/plugins/molten.lua) caps it at 20 lines. Adjust to taste. Use `<leader>mo` to scroll inside it.

--- a/docs/KEYMAPS.md
+++ b/docs/KEYMAPS.md
@@ -1,0 +1,234 @@
+# Keybindings
+
+Reference for every keybinding configured in this Neovim setup. The leader key is `<space>`.
+
+> **Discovery:** press `<leader>` (or any registered prefix) and wait — [which-key.nvim](https://github.com/folke/which-key.nvim) will show available continuations live. This file is the static reference; if it disagrees with the running config, the config wins.
+>
+> When you add or change a keymap, also update this file and (if introducing a new prefix) register a group in [`lua/plugins/which-key.lua`](../lua/plugins/which-key.lua).
+
+## Conventions
+
+- `n` normal · `i` insert · `v` visual · `x` visual-block · `t` terminal · `s` select · `o` operator-pending
+- All `<leader>X` bindings start with `<space>`.
+
+---
+
+## Editing
+
+| Mode | Keys | Action |
+|---|---|---|
+| `i` | `jk` | Exit insert mode |
+| `v` | `J` / `K` | Move selected lines down / up |
+| `n` | `J` | Join lines (cursor stays put) |
+| `x` | `<leader>p` | Paste over selection without clobbering register |
+| `n` | `<leader>F` | Format buffer (conform.nvim) |
+
+## Movement & search
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `<C-d>` / `<C-u>` | Half-page down / up, cursor centered |
+| `n` | `n` / `N` | Next / previous match, centered |
+| `n` | `*` | Search word under cursor, centered |
+| `n` | `<leader>h` / `j` / `k` / `l` | Move to window left / down / up / right |
+
+## Files & buffers
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `<leader>w` | Save |
+| `n` | `<leader>q` | Quit |
+| `n` | `<leader>e` | Toggle NvimTree |
+| `n` | `<leader>E` | Toggle NvimTree, locate current file |
+| `n` | `-` | Open parent directory in [oil.nvim](https://github.com/stevearc/oil.nvim) |
+
+## Telescope (`<leader>f` group)
+
+| Keys | Action |
+|---|---|
+| `<leader>ff` | Find files |
+| `<leader>fg` | Live grep |
+| `<leader>fG` | Grep with prompt |
+| `<leader>fb` | Buffers |
+| `<leader>fh` | Help tags |
+| `<leader>fl` | Fuzzy find in current buffer |
+| `<leader>fp` | Resume previous Telescope picker |
+| `<leader>sw` | Grep word under cursor |
+| `<leader>sW` | Grep WORD under cursor |
+| `<leader>fr` | LSP references |
+| `<leader>fi` | LSP incoming calls |
+| `<leader>fo` | LSP outgoing calls |
+| `<leader>fc` | Git commits |
+| `<leader>fs` | Git status |
+| `<leader>m`  | Git branches |
+| `<C-p>` | Git files |
+
+## LSP
+
+Active when an LSP is attached. Python uses `pyright` (types/hover) + `ruff` (lint + format via conform).
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `gD` | Go to declaration |
+| `n` | `gd` | Go to definition |
+| `n` | `gi` | Go to implementation |
+| `n` | `gr` | References |
+| `n` | `K` | Hover |
+| `n` | `<C-k>` | Signature help |
+| `n` | `<leader>D` | Type definition |
+| `n` | `<leader>rn` | Rename |
+| `n,v` | `<leader>ca` | Code action |
+| `n` | `<leader>f` | LSP format buffer (raw `vim.lsp.buf.format`) |
+| `n` | `<leader>wa` / `wr` / `wl` | Workspace folder add / remove / list |
+| `n` | `[d` / `]d` | Next / previous diagnostic |
+
+## Trouble (`<leader>x` group)
+
+| Keys | Action |
+|---|---|
+| `<leader>xx` | Toggle Trouble |
+| `<leader>xw` | Workspace diagnostics |
+| `<leader>xd` | Document diagnostics |
+| `<leader>xq` | Quickfix |
+| `<leader>xl` | Location list |
+| `[x` / `]x` | Previous / next Trouble item |
+| `gR` | LSP references in Trouble |
+
+## Git
+
+### Fugitive
+
+| Keys | Action |
+|---|---|
+| `<leader>gs` | `:Git` (status) |
+| `<leader>p` | Push (in Fugitive buffer) |
+| `<leader>P` | Pull --merge (in Fugitive buffer) |
+| `<leader>t` | `:Git push -u origin ` (in Fugitive buffer; type branch then `<CR>`) |
+| `gu` / `gh` | Diffget left / right (merge conflicts) |
+| `<leader>g` | Open LazyGit |
+
+### Gitsigns hunks (`<leader>h` group)
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `]c` / `[c` | Next / previous hunk |
+| `n,v` | `<leader>hs` | Stage hunk |
+| `n,v` | `<leader>hr` | Reset hunk |
+| `n` | `<leader>hS` | Stage buffer |
+| `n` | `<leader>hu` | Undo stage |
+| `n` | `<leader>hR` | Reset buffer |
+| `n` | `<leader>hp` | Preview hunk |
+| `n` | `<leader>hb` | Blame line |
+| `n` | `<leader>hd` / `hD` | Diff this / vs HEAD |
+| `n` | `<leader>tb` | Toggle inline blame |
+| `n` | `<leader>td` | Toggle deleted |
+| `o,x` | `ih` | Text object: inside hunk |
+
+## Harpoon (`<leader>m*` and `<C-*>`)
+
+| Keys | Action |
+|---|---|
+| `<leader>a` | Add file to harpoon list |
+| `<C-e>` | Toggle quick menu |
+| `<leader>ma` / `ms` / `md` / `mf` | Jump to slot 1 / 2 / 3 / 4 |
+| `<C-S-P>` / `<C-S-N>` | Previous / next harpoon entry |
+
+## Molten — Jupyter cells (`<leader>m*`)
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `<leader>mi` | Init kernel (`:MoltenInit`) |
+| `n` | `<leader>me` | Evaluate operator |
+| `n` | `<leader>ml` | Evaluate line |
+| `n` | `<leader>mc` | Re-evaluate cell |
+| `v` | `<leader>mv` | Evaluate visual |
+| `n` | `<leader>mo` | Enter output window |
+| `n` | `<leader>mh` | Hide output |
+| `n` | `<leader>mq` | Delete cell |
+
+> Harpoon and Molten share the `<leader>m` prefix but use disjoint suffixes. See [`AGENTS.md`](../AGENTS.md) for the Python/Jupyter setup steps.
+
+## Tabs (Tabby, `<leader>t` group)
+
+| Keys | Action |
+|---|---|
+| `<leader>ta` | New tab |
+| `<leader>tc` | Close tab |
+| `<leader>to` | Close all other tabs |
+| `<leader>tn` / `tp` | Next / previous tab |
+| `<leader>tmn` / `tmp` | Move tab forward / back |
+| `<Tab>` / `<S-Tab>` | Next / previous tab |
+
+## Completion (nvim-cmp, insert mode)
+
+| Keys | Action |
+|---|---|
+| `<C-Space>` | Trigger menu |
+| `<C-n>` / `<C-p>` | Next / previous item |
+| `<CR>` | Confirm selection |
+| `<C-e>` | Abort menu |
+| `<C-b>` / `<C-f>` | Scroll docs up / down |
+
+## Snippets (LuaSnip)
+
+| Mode | Keys | Action |
+|---|---|---|
+| `i` | `<C-k>` | Expand or jump forward |
+| `i,s` | `<C-j>` | Jump backward |
+| `i,s` | `<c-l>` | Cycle choice node |
+
+## Copilot
+
+| Mode | Keys | Action |
+|---|---|---|
+| `i` | `<C-c>` | Accept Copilot suggestion |
+
+### CopilotChat (`<leader>cc` group)
+
+| Mode | Keys | Action |
+|---|---|---|
+| `n` | `<leader>cc` | Open chat |
+| `n` | `<leader>ccm` | Generate commit message |
+| `n` | `<leader>cct` | Generate tests |
+| `n,v` | `<leader>cce` | Explain |
+| `n,v` | `<leader>ccr` | Review |
+| `n,v` | `<leader>ccR` | Refactor |
+| `n,v` | `<leader>ccn` | Suggest better names |
+| `n,v` | `<leader>ccd` | Generate documentation |
+| `n,v` | `<leader>ccf` | Fix code |
+| `n,v` | `<leader>ccF` | Fix diagnostic |
+
+## Misc
+
+| Keys | Action |
+|---|---|
+| `<leader>u` | Toggle undo tree |
+| `<leader>zz` | Zen mode |
+| `<leader>zZ` | Zen mode (80 columns) |
+
+## Comment.nvim (default operators)
+
+| Keys | Action |
+|---|---|
+| `gcc` | Toggle line comment |
+| `gbc` | Toggle block comment |
+| `gc` / `gb` | Operator-pending line / block comment |
+| `gcO` / `gco` | Add comment above / below |
+| `gcA` | Add comment at end of line |
+
+## Surround (default)
+
+`ys{motion}{char}` add · `cs{old}{new}` change · `ds{char}` delete · in visual: `S{char}`.
+
+---
+
+## Known prefix overlaps
+
+These work but cause a brief `timeoutlen` delay because the bare key is mapped *and* a prefix:
+
+- `<leader>h` — bare: window-left; prefix: gitsigns hunks
+- `<leader>w` — bare: save; prefix: LSP workspace (`wa`/`wr`/`wl`)
+- `<leader>p` — `x`-mode paste; `n`-mode Fugitive push (different modes, no conflict)
+- `<leader>m` — bare: telescope branches; prefix: harpoon + molten
+
+If a delay annoys you, rebind the bare key (or move the prefix). which-key will pop up the menu during the wait.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,166 @@
+# Setup
+
+How to get this Neovim config running from scratch on **macOS** and **Arch Linux**. The two paths share the same end state — only the package manager differs.
+
+> Keep this doc honest: if you change a system-level dependency in the config (a new LSP that needs a system binary, a new image backend, etc.), update the relevant section here.
+
+---
+
+## What you'll end up with
+
+- Neovim ≥ 0.10
+- A Kitty-graphics-protocol terminal (for inline matplotlib output)
+- Python with `pynvim` + Jupyter client libs (for molten-nvim)
+- Node.js (most of the LSPs are npm packages installed by Mason)
+- Formatters and CLI tools used by plugins: ImageMagick, ripgrep, fd, lazygit, stylua, prettierd
+
+---
+
+## macOS
+
+### 1. System packages (Homebrew)
+
+```bash
+brew install neovim git ripgrep fd imagemagick lazygit stylua node python
+brew install --cask kitty                 # or font-hack-nerd-font + your terminal of choice
+brew install --cask font-jetbrains-mono-nerd-font
+```
+
+> If you already use a Kitty-protocol terminal (Ghostty, WezTerm), skip the `kitty` cask. Other terminals (Terminal.app, iTerm2, Alacritty) work for everything *except* inline image rendering — you'll see molten output as text only.
+
+### 2. Python (Jupyter / molten)
+
+Use whichever Python you'll edit notebooks against — system, pyenv, or a venv. Install into the active environment:
+
+```bash
+pip install pynvim jupyter_client cairosvg pnglatex pillow ipykernel ruff jupytext
+```
+
+> `ruff` is the Python linter/formatter; conform.nvim shells out to it. Mason also installs a `ruff` LSP — both rely on the `ruff` binary being on `$PATH`.
+> `jupytext` is the CLI tool that jupytext.nvim shells out to when opening/saving `.ipynb` files. Without it, `.ipynb` files will display as raw JSON.
+
+### 3. Node-based formatters
+
+```bash
+npm install -g prettier prettierd
+```
+
+### 4. Clone and bootstrap
+
+```bash
+git clone <this-repo> ~/.config/nvim
+cd ~/.config/nvim
+nvim
+# inside nvim:
+:Lazy sync                 # installs all plugins
+:UpdateRemotePlugins       # registers molten's Python remote plugin
+:checkhealth               # verify providers, treesitter, mason
+```
+
+Restart Neovim once after `:UpdateRemotePlugins`.
+
+### 5. Smoke test
+
+Open a `.py` file with `# %%` cell markers, then:
+
+```vim
+:MoltenInit python3
+```
+
+Press `<leader>ml` on a line — output should appear as virtual text.
+
+---
+
+## Arch Linux
+
+### 1. System packages (pacman)
+
+```bash
+sudo pacman -S neovim git ripgrep fd imagemagick lazygit stylua nodejs npm python python-pip
+sudo pacman -S xclip wl-clipboard          # required for system clipboard ("unnamedplus")
+sudo pacman -S ttf-jetbrains-mono-nerd     # or any nerd font from the AUR
+```
+
+For a Kitty-protocol terminal:
+
+```bash
+sudo pacman -S kitty
+# or AUR: ghostty (yay -S ghostty)
+# wezterm is in extra: sudo pacman -S wezterm
+```
+
+### 2. Python (Jupyter / molten)
+
+Arch's Python is PEP 668-managed — install into a venv (recommended) or use `--user`:
+
+```bash
+# venv approach (recommended)
+python -m venv ~/.venvs/nvim
+source ~/.venvs/nvim/bin/activate
+pip install pynvim jupyter_client cairosvg pnglatex pillow ipykernel ruff jupytext
+
+# tell nvim where this Python lives (add to ~/.config/nvim/init.lua or shell rc)
+# vim.g.python3_host_prog = vim.fn.expand("~/.venvs/nvim/bin/python")
+```
+
+If you go the user-install route instead:
+
+```bash
+pip install --user --break-system-packages pynvim jupyter_client cairosvg pnglatex pillow ipykernel ruff jupytext
+```
+
+> Setting `vim.g.python3_host_prog` to the venv's `python` is the cleanest pattern — molten and other Python plugins will use exactly that interpreter regardless of what's on `$PATH`.
+
+### 3. Node-based formatters
+
+```bash
+sudo npm install -g prettier prettierd
+```
+
+### 4. Clone and bootstrap
+
+```bash
+git clone <this-repo> ~/.config/nvim
+cd ~/.config/nvim
+nvim
+# inside nvim:
+:Lazy sync
+:UpdateRemotePlugins
+:checkhealth
+```
+
+Restart Neovim once after `:UpdateRemotePlugins`.
+
+### 5. Smoke test
+
+Same as macOS: `:MoltenInit python3`, then `<leader>ml` on a line of a `.py` file.
+
+---
+
+## Verifying the install
+
+Run `:checkhealth` and check:
+
+- **provider.python** — `python3_host_prog` resolves and `pynvim` ≥ 1.5 is installed
+- **mason** — all configured LSPs install green; if not, `:Mason` and trigger them manually
+- **nvim-treesitter** — `python`, `markdown`, `markdown_inline` parsers compiled
+- **image.nvim** — backend reports as `kitty`, ImageMagick found
+- **molten** — no errors; if `:MoltenInit` says "remote plugin not registered", re-run `:UpdateRemotePlugins` and restart
+
+---
+
+## Common gotchas
+
+- **`:MoltenInit` errors with "no Python provider"** — `pynvim` isn't installed in the Python that nvim uses. Fix `vim.g.python3_host_prog` or install pynvim into the right env.
+- **No matplotlib images** — your terminal doesn't speak the Kitty graphics protocol. Confirmed working: Kitty, Ghostty, WezTerm. Not working: Terminal.app, iTerm2, Alacritty, GNOME Terminal.
+- **Clipboard yanks vanish on Linux** — install `xclip` (X11) or `wl-clipboard` (Wayland).
+- **`ruff` formatter does nothing** — `ruff` binary missing on `$PATH`. `pip install ruff` (or `pacman -S ruff`).
+- **TypeScript/Angular LSP missing** — Mason installs npm packages; needs working `node`/`npm`.
+
+---
+
+## Optional but recommended
+
+- **Nerd Font** — without one, nvim-tree, lualine, and trouble icons render as boxes.
+- **lazygit config** — see [`~/.config/lazygit/config.yml`](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md) for keybinding tweaks.
+- **`ipykernel` per project** — for project-specific kernels: `python -m ipykernel install --user --name myproject`.

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -1,0 +1,30 @@
+return {
+    "stevearc/conform.nvim",
+    event = { "BufWritePre" },
+    cmd = { "ConformInfo" },
+    keys = {
+        {
+            "<leader>F",
+            function()
+                require("conform").format({ async = true, lsp_fallback = true })
+            end,
+            mode = { "n", "v" },
+            desc = "Format buffer",
+        },
+    },
+    opts = {
+        formatters_by_ft = {
+            python = { "ruff_organize_imports", "ruff_format" },
+            lua = { "stylua" },
+            javascript = { "prettierd", "prettier", stop_after_first = true },
+            typescript = { "prettierd", "prettier", stop_after_first = true },
+            javascriptreact = { "prettierd", "prettier", stop_after_first = true },
+            typescriptreact = { "prettierd", "prettier", stop_after_first = true },
+            json = { "prettierd", "prettier", stop_after_first = true },
+            css = { "prettierd", "prettier", stop_after_first = true },
+            scss = { "prettierd", "prettier", stop_after_first = true },
+            html = { "prettierd", "prettier", stop_after_first = true },
+            markdown = { "prettierd", "prettier", stop_after_first = true },
+        },
+    },
+}

--- a/lua/plugins/image.lua
+++ b/lua/plugins/image.lua
@@ -1,0 +1,23 @@
+return {
+    "3rd/image.nvim",
+    -- requires `brew install imagemagick` on macOS
+    opts = {
+        backend = "kitty",
+        processor = "magick_cli",
+        integrations = {
+            markdown = {
+                enabled = true,
+                clear_in_insert_mode = false,
+                download_remote_images = true,
+                only_render_image_at_cursor = false,
+                filetypes = { "markdown", "vimwiki", "quarto" },
+            },
+        },
+        max_width = 100,
+        max_height = 12,
+        max_height_window_percentage = 30,
+        max_width_window_percentage = math.huge,
+        window_overlap_clear_enabled = true,
+        window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "" },
+    },
+}

--- a/lua/plugins/jupytext.lua
+++ b/lua/plugins/jupytext.lua
@@ -1,0 +1,9 @@
+return {
+    "GCBallesteros/jupytext.nvim",
+    lazy = false,
+    opts = {
+        style = "markdown",
+        output_extension = "md",
+        force_ft = "markdown",
+    },
+}

--- a/lua/plugins/molten.lua
+++ b/lua/plugins/molten.lua
@@ -1,0 +1,25 @@
+return {
+    "benlubas/molten-nvim",
+    -- remote plugins must not be lazy-loaded or :UpdateRemotePlugins won't find them
+    lazy = false,
+    build = ":UpdateRemotePlugins",
+    dependencies = { "3rd/image.nvim" },
+    init = function()
+        vim.g.molten_image_provider = "image.nvim"
+        vim.g.molten_output_win_max_height = 20
+        vim.g.molten_auto_open_output = false
+        vim.g.molten_virt_text_output = true
+        vim.g.molten_virt_lines_off_by_1 = true
+        vim.g.molten_wrap_output = true
+    end,
+    keys = {
+        { "<leader>mi", ":MoltenInit<CR>",                    desc = "Molten: init kernel" },
+        { "<leader>me", ":MoltenEvaluateOperator<CR>",        desc = "Molten: evaluate operator" },
+        { "<leader>ml", ":MoltenEvaluateLine<CR>",            desc = "Molten: evaluate line" },
+        { "<leader>mc", ":MoltenReevaluateCell<CR>",          desc = "Molten: re-evaluate cell" },
+        { "<leader>mv", ":<C-u>MoltenEvaluateVisual<CR>gv",   mode = "v", desc = "Molten: evaluate visual" },
+        { "<leader>mo", ":noautocmd MoltenEnterOutput<CR>",   desc = "Molten: enter output window" },
+        { "<leader>mh", ":MoltenHideOutput<CR>",              desc = "Molten: hide output" },
+        { "<leader>mq", ":MoltenDelete<CR>",                  desc = "Molten: delete cell" },
+    },
+}

--- a/lua/plugins/neoformat.lua
+++ b/lua/plugins/neoformat.lua
@@ -1,3 +1,0 @@
-return{
-	"sbdchd/neoformat"
-}

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -13,7 +13,6 @@ return {
         "L3MON4D3/LuaSnip",
         "saadparwaiz1/cmp_luasnip",
         "j-hui/fidget.nvim",
-        'nvim-java/nvim-java'
     },
     config = function()
         local cmp = require("cmp")
@@ -27,7 +26,6 @@ return {
 
         require("fidget").setup({})
         require("mason").setup()
-        require('java').setup({})
         require("mason-lspconfig").setup({
             ensure_installed = {
                 "eslint",
@@ -39,7 +37,8 @@ return {
                 "tailwindcss",
                 "angularls",
                 "astro",
-                "jdtls"
+                "pyright",
+                "ruff",
             },
             handlers = {
                 function(server_name) -- default handler (optional)
@@ -62,23 +61,30 @@ return {
                     })
                 end,
 
-                ['jdtls'] = function()
-                    local lspConfig = require('lspconfig')
-                    lspConfig.jdtls.setup({
+                ["pyright"] = function()
+                    local lspconfig = require("lspconfig")
+                    lspconfig.pyright.setup({
+                        capabilities = capabilities,
                         settings = {
-                            java = {
-                                configuration = {
-                                    runtimes = {
-                                        {
-                                            name = "Coretto 21",
-                                            path = "/Users/colcloub/Library/Java/JavaVirtualMachines",
-                                            default = true,
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                            python = {
+                                analysis = {
+                                    typeCheckingMode = "basic",
+                                    autoSearchPaths = true,
+                                    useLibraryCodeForTypes = true,
+                                },
+                            },
+                        },
+                    })
+                end,
 
+                ["ruff"] = function()
+                    local lspconfig = require("lspconfig")
+                    lspconfig.ruff.setup({
+                        capabilities = capabilities,
+                        on_attach = function(client, _)
+                            -- let pyright own hovers
+                            client.server_capabilities.hoverProvider = false
+                        end,
                     })
                 end,
 

--- a/lua/plugins/quarto.lua
+++ b/lua/plugins/quarto.lua
@@ -1,0 +1,21 @@
+return {
+    "quarto-dev/quarto-nvim",
+    ft = { "quarto", "markdown" },
+    dependencies = {
+        { "jmbuhr/otter.nvim", opts = {} },
+        "nvim-treesitter/nvim-treesitter",
+    },
+    opts = {
+        codeRunner = {
+            enabled = true,
+            default_method = "molten",
+        },
+        lspFeatures = {
+            enabled = true,
+            languages = { "python" },
+            chunks = "all",
+            diagnostics = { enabled = true, triggers = { "BufWritePost" } },
+            completion = { enabled = true },
+        },
+    },
+}

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -6,7 +6,10 @@ return {
 
         configs.setup({
             -- A list of parser names, or "all"
-            ensure_installed = { 'typescript', 'html', 'javascript', 'angular', 'json', 'json5', 'rust', 'css', 'scss', 'java' },
+            ensure_installed = {
+                'typescript', 'html', 'javascript', 'angular', 'json', 'json5', 'rust', 'css', 'scss',
+                'python', 'markdown', 'markdown_inline', 'lua', 'vim', 'vimdoc',
+            },
 
             -- Install parsers synchronously (only applied to `ensure_installed`)
             sync_install = false,

--- a/lua/plugins/which-key.lua
+++ b/lua/plugins/which-key.lua
@@ -1,0 +1,24 @@
+return {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    opts = {
+        preset = "modern",
+        delay = 300,
+    },
+    config = function(_, opts)
+        local wk = require("which-key")
+        wk.setup(opts)
+        wk.add({
+            { "<leader>f",  group = "find / telescope" },
+            { "<leader>h",  group = "git hunks" },
+            { "<leader>x",  group = "trouble / diagnostics" },
+            { "<leader>m",  group = "molten / harpoon" },
+            { "<leader>c",  group = "code / copilot" },
+            { "<leader>cc", group = "copilot chat" },
+            { "<leader>t",  group = "tabs" },
+            { "<leader>z",  group = "zen-mode" },
+            { "<leader>g",  group = "git" },
+            { "<leader>s",  group = "search word" },
+        })
+    end,
+}

--- a/lua/remap.lua
+++ b/lua/remap.lua
@@ -1,6 +1,3 @@
-local map = vim.api.nvim_set_keymap
-local opts = { noremap = true, silent = true }
-
 local set = vim.opt
 
 vim.g.mapleader = " "
@@ -36,46 +33,33 @@ set.clipboard = "unnamedplus"
 
 set.colorcolumn = "120"
 
-map("i", "jk", "<Esc>", opts)
+vim.keymap.set("i", "jk", "<Esc>", { noremap = true, silent = true, desc = "Exit insert mode" })
 
 -- move highlighted code up and down lines
-vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv")
-vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
+vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
+vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
 
 -- keep cursor in the same location when joining lines
-vim.keymap.set("n", "J", "mzJ`z")
+vim.keymap.set("n", "J", "mzJ`z", { desc = "Join lines (keep cursor)" })
 
--- user leader P to paste over visual selection and not lose the contents of the register
-vim.keymap.set("x", "<leader>p", [["_dP]])
+-- use leader P to paste over visual selection and not lose the contents of the register
+vim.keymap.set("x", "<leader>p", [["_dP]], { desc = "Paste over selection (keep register)" })
 
 -- ensure cursor is always in the middle of the screen
-vim.keymap.set("n", "<C-d>", "<C-d>zz")
-vim.keymap.set("n", "<C-u>", "<C-u>zz")
-vim.keymap.set("n", "n", "nzzzv")
-vim.keymap.set("n", "N", "Nzzzv")
-vim.keymap.set("n", "*", "*zzzv")
+vim.keymap.set("n", "<C-d>", "<C-d>zz", { desc = "Half-page down (centered)" })
+vim.keymap.set("n", "<C-u>", "<C-u>zz", { desc = "Half-page up (centered)" })
+vim.keymap.set("n", "n", "nzzzv", { desc = "Next search result (centered)" })
+vim.keymap.set("n", "N", "Nzzzv", { desc = "Prev search result (centered)" })
+vim.keymap.set("n", "*", "*zzzv", { desc = "Search word under cursor (centered)" })
 
 -- window movement
-map("n", "<leader>h", "<C-w>h", opts)
-map("n", "<leader>l", "<C-w>l", opts)
-map("n", "<leader>k", "<C-w>k", opts)
-map("n", "<leader>j", "<C-w>j", opts)
+vim.keymap.set("n", "<leader>h", "<C-w>h", { noremap = true, silent = true, desc = "Window: move left" })
+vim.keymap.set("n", "<leader>l", "<C-w>l", { noremap = true, silent = true, desc = "Window: move right" })
+vim.keymap.set("n", "<leader>k", "<C-w>k", { noremap = true, silent = true, desc = "Window: move up" })
+vim.keymap.set("n", "<leader>j", "<C-w>j", { noremap = true, silent = true, desc = "Window: move down" })
 
-map("n", "<leader>q", ":q<CR>", opts)
-map("n", "<leader>w", ":w<CR>", opts)
+vim.keymap.set("n", "<leader>q", ":q<CR>", { noremap = true, silent = true, desc = "Quit" })
+vim.keymap.set("n", "<leader>w", ":w<CR>", { noremap = true, silent = true, desc = "Save" })
 
--- terminal mappings
-if vim.fn.has("win32") or vim.fn.has("win64") then
-    map("n", "<leader>vt", ":80vsplit term://powershell<CR>", opts) -- for Windows
-    map("n", "<leader>t", ":terminal powershell.exe<CR>", opts)     -- for Windows
-end
-
-if vim.fn.has("macunix") then
-    map("n", "<leader>vt", ":80vsplit term://zsh<CR>", opts) -- for Mac
-    map("n", "<leader>t", ":terminal zsh<CR>", opts)         -- for Mac
-end
-
-map("t", "<C-j>", "<C-\\><C-n>", opts)
-
--- mappings for autofomat
-map("n", "<leader>F", ":Neoformat<CR>", opts)
+-- escape from terminal-mode (used when :terminal is opened manually)
+vim.keymap.set("t", "<C-j>", [[<C-\><C-n>]], { noremap = true, silent = true, desc = "Exit terminal mode" })


### PR DESCRIPTION
## Summary

Reorients this Neovim config from its inherited web-dev focus toward Python and Jupyter notebooks (the actual day-to-day use case), removes the dormant Java tooling, and adds versioned documentation so future changes stay coherent.

## What changed

### Removed
- `nvim-java/nvim-java` dep, `jdtls` handler (had a hardcoded `/Users/colcloub/Library/Java/JavaVirtualMachines` path), `java` treesitter parser
- `lua/plugins/neoformat.lua` (was installed but unconfigured)
- `<leader>t` / `<leader>vt` terminal mappings — they conflicted with tabby's `<leader>t*` tab prefix

### Added — Python language tooling
- `pyright` (types, hover) + `ruff` (lint) via Mason in [`lua/plugins/nvim-cmp.lua`](lua/plugins/nvim-cmp.lua); `ruff`'s hoverProvider is disabled so pyright owns hovers
- [`lua/plugins/conform.lua`](lua/plugins/conform.lua) — `ruff_organize_imports` → `ruff_format` for Python, plus prettier/stylua chains for other languages. `<leader>F` formats.
- treesitter parsers: `python`, `markdown`, `markdown_inline`, `lua`, `vim`, `vimdoc`

### Added — Jupyter notebook stack
- [`molten-nvim`](https://github.com/benlubas/molten-nvim) for cell execution (loaded eagerly because remote plugins must be in `rtp` when `:UpdateRemotePlugins` runs)
- [`jupytext.nvim`](https://github.com/GCBallesteros/jupytext.nvim) — `.ipynb` ↔ markdown conversion on read/write
- [`quarto-nvim`](https://github.com/quarto-dev/quarto-nvim) + `otter.nvim` — LSP features inside cells
- [`image.nvim`](https://github.com/3rd/image.nvim) with kitty backend for inline matplotlib output

### Added — which-key
- [`folke/which-key.nvim`](https://github.com/folke/which-key.nvim) v3 with group labels registered for `<leader>f`, `<leader>h`, `<leader>x`, `<leader>m`, `<leader>c/cc`, `<leader>t`, `<leader>z`, `<leader>g`, `<leader>s`
- Converted leader-prefixed maps in `lua/remap.lua` to `vim.keymap.set` with `desc` fields so which-key labels them

### Added — docs
- [`docs/SETUP.md`](docs/SETUP.md) — install steps for macOS (Homebrew) and Arch Linux (pacman + venv)
- [`docs/JUPYTER.md`](docs/JUPYTER.md) — how to open `.ipynb` files, run cells, and troubleshoot common issues
- [`docs/KEYMAPS.md`](docs/KEYMAPS.md) — full keybinding reference, organized by category, with a "known prefix overlaps" section
- [`AGENTS.md`](AGENTS.md) — conventions for AI agents (Claude Code, Copilot) and humans alike: where LSPs/formatters/parsers live, when to update which doc, install gotchas
- [`CLAUDE.md`](CLAUDE.md) — single-line pointer to `AGENTS.md`

## Why

- **Java tooling was dead weight** — never used in practice and the JVM path was tied to a different machine.
- **Python had no tooling at all** — no LSP, no formatter, no treesitter parser, despite Python being the primary editing target.
- **Jupyter support** — needed for editing `.ipynb` files inline with kernel execution and inline plots.
- **which-key + docs** — surface the keymap reality. There were ~80 leader-prefixed bindings spread across 25 plugin files; this makes them discoverable both interactively (which-key) and statically (KEYMAPS.md).

## Reviewer notes

- `lazy-lock.json` is intentionally not modified by hand — `:Lazy sync` will prune the stale `nvim-java*` entries and add the new plugins on next run.
- molten-nvim is `lazy = false` deliberately. With `ft` lazy-loading, the plugin isn't in the runtimepath when `:UpdateRemotePlugins` scans, so its remote commands (`:MoltenInit` etc.) never get registered. This was caught during testing.
- The `<leader>m` prefix is shared between Harpoon (`ma/ms/md/mf` for slots 1–4) and Molten (`mi/me/ml/mc/mv/mo/mh/mq`). Suffixes are disjoint, so they coexist; documented in `KEYMAPS.md`.

## Test plan

- [ ] `git checkout` this branch in `~/.config/nvim` (or merge to main)
- [ ] `:Lazy sync` — completes cleanly; `lazy-lock.json` no longer references `nvim-java*`
- [ ] `:UpdateRemotePlugins` then **restart Neovim**
- [ ] `rg -i 'java|jdtls' --type lua` returns no real Java references (only "javascript" strings and the AGENTS.md "don't add Java" line)
- [ ] Open a `.py` file: `:LspInfo` shows `pyright` and `ruff` attached
- [ ] `<leader>F` on a messy Python file: ruff formats and organizes imports
- [ ] Press `<space>` and wait: which-key popup shows group labels
- [ ] `pip install pynvim jupyter_client cairosvg pnglatex pillow ipykernel ruff jupytext` (and `brew install imagemagick`)
- [ ] Open a `.ipynb` file: renders as markdown (not raw JSON)
- [ ] `:MoltenInit python3` then `<leader>ml` on a `print("hi")` line: output appears as virtual text
- [ ] `import matplotlib.pyplot as plt; plt.plot([1,2,3]); plt.show()`: image renders inline (Kitty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)