### PR TITLE
Add quarto runner keymaps for whole-notebook execution

### DIFF
--- a/docs/JUPYTER.md
+++ b/docs/JUPYTER.md
@@ -99,6 +99,21 @@ Then use these keymaps (leader = `<space>`):
 
 Output appears as virtual text below the cell. For plots, the image renders inline (requires Kitty terminal — see below).
 
+### Running the whole notebook
+
+Molten itself only evaluates lines/operators/visual selections — it doesn't know what a "cell" is. The cell-aware "run everything" commands come from **quarto-nvim**, which is configured here to dispatch to molten:
+
+| Keys | Action |
+|---|---|
+| `<leader>mA` | Run **all** cells in the buffer |
+| `<leader>mB` | Run all cells **below** the cursor |
+| `<leader>mU` | Run all cells **above** the cursor |
+| `<leader>mC` | Run the current cell (whole markdown fence) |
+
+These understand the ` ```python ... ``` ` cell fences that jupytext produces, so they Just Work on a `.ipynb` opened through this config. Equivalent function form: `:lua require("quarto.runner").run_all()`.
+
+> Make sure you've called `:MoltenInit python3` once first — quarto's runner dispatches to whatever kernel molten has attached. If no kernel is running, the calls become no-ops.
+
 ---
 
 ## Inline plots (Kitty)

--- a/docs/KEYMAPS.md
+++ b/docs/KEYMAPS.md
@@ -145,6 +145,10 @@ Active when an LSP is attached. Python uses `pyright` (types/hover) + `ruff` (li
 | `n` | `<leader>mo` | Enter output window |
 | `n` | `<leader>mh` | Hide output |
 | `n` | `<leader>mq` | Delete cell |
+| `n` | `<leader>mA` | Run **all** cells (via quarto runner) |
+| `n` | `<leader>mB` | Run all cells **below** cursor |
+| `n` | `<leader>mU` | Run all cells **above** cursor (Up) |
+| `n` | `<leader>mC` | Run current cell (markdown-fence aware) |
 
 > Harpoon and Molten share the `<leader>m` prefix but use disjoint suffixes. See [`AGENTS.md`](../AGENTS.md) for the Python/Jupyter setup steps.
 

--- a/lua/plugins/quarto.lua
+++ b/lua/plugins/quarto.lua
@@ -18,4 +18,14 @@ return {
             completion = { enabled = true },
         },
     },
+    keys = {
+        { "<leader>mA", function() require("quarto.runner").run_all() end,
+            desc = "Quarto/Molten: run all cells" },
+        { "<leader>mB", function() require("quarto.runner").run_below() end,
+            desc = "Quarto/Molten: run cells below cursor" },
+        { "<leader>mU", function() require("quarto.runner").run_above() end,
+            desc = "Quarto/Molten: run cells above cursor" },
+        { "<leader>mC", function() require("quarto.runner").run_cell() end,
+            desc = "Quarto/Molten: run current cell" },
+    },
 }


### PR DESCRIPTION
## Summary

Adds keymaps for running an entire Jupyter notebook (or cells above/below the cursor) via quarto-nvim's runner, which dispatches to molten.

## Why quarto, not molten directly?

Molten evaluates lines, operators, and visual selections — it doesn't know what a markdown cell fence is. quarto-nvim's runner understands the ` ```python ... ``` ` fences that jupytext produces from `.ipynb` files, making it the right layer for "run whole notebook" semantics.

## Changes

**`lua/plugins/quarto.lua`** — added `keys` spec:

| Key | Action |
|---|---|
| `<leader>mA` | Run all cells in buffer |
| `<leader>mB` | Run all cells below cursor |
| `<leader>mU` | Run all cells above cursor |
| `<leader>mC` | Run current cell (whole fence) |

Uppercase suffixes keep these disjoint from Harpoon's `<leader>ma/ms/md/mf`.

**`docs/KEYMAPS.md`** — four new rows in the Molten table.

**`docs/JUPYTER.md`** — new "Running the whole notebook" section explaining the quarto/molten split and the `:MoltenInit` prerequisite.

## Test plan

- [ ] `:Lazy sync`
- [ ] Open a `.ipynb`, `:MoltenInit python3`
- [ ] `<leader>mA` — all cells execute top to bottom
- [ ] `<leader>mB` / `<leader>mU` — only cells below/above cursor run
- [ ] `<leader>mC` — only the cell under the cursor runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)